### PR TITLE
Remove ex_machina from application list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,7 @@ defmodule ParticipateApi.Mixfile do
   def application do
     [mod: {ParticipateApi, []},
      applications: [:phoenix, :cowboy, :logger, :gettext,
-                    :phoenix_ecto, :postgrex, :httpotion,
-                    :ex_machina]]
+                    :phoenix_ecto, :postgrex, :httpotion]]
   end
 
   # Specifies which paths to compile per environment.


### PR DESCRIPTION
ex_machina is only a test dependency now.

Otherwise the app will not start:
```sh
> mix phoenix.server
** (Mix) Could not start application ex_machina: could not find application file: ex_machina.app
```
