### PR TITLE
Document DB migration step

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Create a database `participate_api_dev` and insert initial data:
 $ mix ecto.setup
 ```
 
+To migrate an existing database to a new version of the API server do this instead:
+
+```sh
+$ mix ecto.migrate
+```
+
 Start the API server:
 
 ```sh


### PR DESCRIPTION
New versions of the backend may often introduce changes to the database schema. An existing database should be updated using the command `mix ecto.migrate`.

Document this in the Readme.