### PR TITLE
Bugfix: Booleans should be atoms, not strings

### DIFF
--- a/spec/requests/proposals_spec.exs
+++ b/spec/requests/proposals_spec.exs
@@ -40,8 +40,8 @@ defmodule ParticipateApi.ProposalsSpec do
                 "title" => proposal.title,
                 "body"=> proposal.body,
                 "support-count" => 0,
-                "supported-by-me" => "false",
-                "authored-by-me" => "false"
+                "supported-by-me" => false,
+                "authored-by-me" => false
               },
               "relationships" => %{
                 "author" => %{
@@ -114,8 +114,8 @@ defmodule ParticipateApi.ProposalsSpec do
               "title" => proposal.title,
               "body"=> proposal.body,
               "support-count" => 0,
-              "supported-by-me" => "false",
-              "authored-by-me" => "true"
+              "supported-by-me" => false,
+              "authored-by-me" => true
             },
             "relationships" => %{
               "author" => %{
@@ -150,7 +150,7 @@ defmodule ParticipateApi.ProposalsSpec do
         it "returns the proposal" do
           response_body = subject.resp_body
           payload = Poison.Parser.parse!(response_body)
-          expect(payload["data"]["attributes"]["authored-by-me"]).to eql("false")
+          expect(payload["data"]["attributes"]["authored-by-me"]).to eql(false)
         end
       end
 
@@ -227,8 +227,8 @@ defmodule ParticipateApi.ProposalsSpec do
               "title" => "Title",
               "body"=> "Body",
               "support-count" => 0,
-              "supported-by-me" => "false",
-              "authored-by-me" => "true"
+              "supported-by-me" => false,
+              "authored-by-me" => true
             },
             "relationships" => %{
               "author" => %{

--- a/spec/requests/supports_spec.exs
+++ b/spec/requests/supports_spec.exs
@@ -87,7 +87,7 @@ defmodule ParticipateApi.SupportsSpec do
               "id" => "#{proposal.id}",
               "attributes" => %{
                 "support-count" => 1,
-                "supported-by-me" => "true",
+                "supported-by-me" => true,
               }
             }
           ], 

--- a/web/views/proposal_view.ex
+++ b/web/views/proposal_view.ex
@@ -20,9 +20,9 @@ defmodule ParticipateApi.ProposalView do
 
   def authored_by_me(proposal, conn) do
     if proposal.author.id == conn.assigns[:account].participant_id do
-      "true"
+      true
     else
-      "false"
+      false
     end
   end
 
@@ -33,9 +33,9 @@ defmodule ParticipateApi.ProposalView do
     me_id = conn.assigns[:account].participant_id
 
     if me_id in support_author_ids do
-      "true"
+      true
     else
-      "false"
+      false
     end
   end
 

--- a/web/views/proposal_with_support_count_view.ex
+++ b/web/views/proposal_with_support_count_view.ex
@@ -23,9 +23,9 @@ defmodule ParticipateApi.ProposalWithSupportCountView do
     me_id = conn.assigns[:account].participant_id
 
     if me_id in support_author_ids do
-      "true"
+      true
     else
-      "false"
+      false
     end
   end
 


### PR DESCRIPTION
A JSON boolean looks like this, i.e. without quotes around `true`:

```json
{ "supported-by-me": true }
```

Accordingly Elixir code should use the builtin atoms `true` and `false` instead of strings like `"true"`. These atoms result in valid JSON code.