### PR TITLE
Configure through environment variables

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,6 +18,7 @@ use Mix.Config
 # which you typically run after static files are built.
 config :participate_api, ParticipateApi.Endpoint,
   http: [port: {:system, "PORT"}],
+  # TODO: Possibly move URL value to env variables
   url: [scheme: "https", host: "participant-api.herokuapp.com", port: 443],
   force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/manifest.json",

--- a/web/adapters/facebook.ex
+++ b/web/adapters/facebook.ex
@@ -28,8 +28,11 @@ defmodule ParticipateApi.Facebook do
   end
 
   defp token_query(fb_dialog_response_code) do
-    # TODO move to env vars
-    "client_id=1583083701926004&client_secret=16b9c526400d10d95589b168dae80d4d&redirect_uri=http://localhost:3000/facebook_redirect&code=#{fb_dialog_response_code}"
+    fb_client_id = System.get_env("FACEBOOK_CLIENT_ID") || "1583083701926004"
+    fb_client_secret = System.get_env("FACEBOOK_CLIENT_SECRET") || "16b9c526400d10d95589b168dae80d4d"
+    fb_redirect_uri = System.get_env("FACEBOOK_REDIRECT_URI") || "http://localhost:3000/facebook_redirect"
+
+    "client_id=#{fb_client_id}&client_secret=#{fb_client_secret}&redirect_uri=#{fb_redirect_uri}&code=#{fb_dialog_response_code}"
   end
 
   defp me_url(access_token) do


### PR DESCRIPTION
Settings for Facebook authentication should be configurable through the use of env vars.